### PR TITLE
feat: Render sidebar group rows with classNames from horizontalLineClassNamesForGroup

### DIFF
--- a/demo/app/demo-main/index.js
+++ b/demo/app/demo-main/index.js
@@ -151,6 +151,9 @@ export default class App extends Component {
     return (
       <Timeline
         groups={groups}
+        horizontalLineClassNamesForGroup={group =>
+          group.title.includes("e") ? ["highlight"] : ""
+        }
         items={items}
         keys={keys}
         sidebarWidth={150}

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -184,7 +184,7 @@ export default class ReactCalendarTimeline extends Component {
 
     traditionalZoom: false,
 
-    horizontalLineClassNamesForGroup: null,
+    horizontalLineClassNamesForGroup: () => [],
 
     onItemMove: null,
     onItemResize: null,
@@ -827,13 +827,15 @@ export default class ReactCalendarTimeline extends Component {
     return (
       sidebarWidth && 
       <Sidebar
-        groups={this.props.groups}
+        groupHeights={groupHeights}
         groupRenderer={this.props.groupRenderer}
+        groups={this.props.groups}
+        height={height}
+        horizontalLineClassNamesForGroup={
+          this.props.horizontalLineClassNamesForGroup
+        }
         keys={this.props.keys}
         width={sidebarWidth}
-        groupHeights={groupHeights}
-        height={height}
-
       />
     )
   }
@@ -843,14 +845,16 @@ export default class ReactCalendarTimeline extends Component {
     return (
       rightSidebarWidth &&
       <Sidebar
-        groups={this.props.groups}
-        keys={this.props.keys}
-        groupRenderer={this.props.groupRenderer}
-        isRightSidebar
-        width={rightSidebarWidth}
         groupHeights={groupHeights}
+        groupRenderer={this.props.groupRenderer}
+        groups={this.props.groups}
+        horizontalLineClassNamesForGroup={
+          this.props.horizontalLineClassNamesForGroup
+        }
         height={height}
-
+        isRightSidebar
+        keys={this.props.keys}
+        width={rightSidebarWidth}
       />
     )
   }

--- a/src/lib/layout/Sidebar.js
+++ b/src/lib/layout/Sidebar.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
+import classNames from 'classnames'
 
 import { _get, arraysEqual } from '../utility/generic'
 
@@ -8,6 +9,7 @@ export default class Sidebar extends Component {
     groups: PropTypes.oneOfType([PropTypes.array, PropTypes.object]).isRequired,
     width: PropTypes.number.isRequired,
     height: PropTypes.number.isRequired,
+    horizontalLineClassNamesForGroup: PropTypes.func.isRequired,
     groupHeights: PropTypes.array.isRequired,
     keys: PropTypes.object.isRequired,
     groupRenderer: PropTypes.func,
@@ -36,7 +38,7 @@ export default class Sidebar extends Component {
   }
 
   render() {
-    const { width, groupHeights, height, isRightSidebar } = this.props
+    const { width, groupHeights, height, horizontalLineClassNamesForGroup, isRightSidebar } = this.props
 
     const { groupIdKey, groupTitleKey, groupRightTitleKey } = this.props.keys
 
@@ -59,7 +61,7 @@ export default class Sidebar extends Component {
         <div
           key={_get(group, groupIdKey)}
           className={
-            'rct-sidebar-row rct-sidebar-row-' + (index % 2 === 0 ? 'even' : 'odd')
+            classNames('rct-sidebar-row', 'rct-sidebar-row-', (index % 2 === 0 ? 'even' : 'odd'), ...horizontalLineClassNamesForGroup(group))
           }
           style={elementStyle}
         >


### PR DESCRIPTION
**Issue Number**
https://github.com/namespace-ee/react-calendar-timeline/issues/605

In response to the above issue, I wonder if `Sidebar` ought to apply the same `horizontalLineClassNamesForGroup` classNames to its rows as the main scrollable area of the timeline does.

Here's how that might look.